### PR TITLE
feat: optional keyv instance injection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,11 +16,15 @@ class CacheableRequest {
 			throw new TypeError('Parameter `request` must be a function');
 		}
 
-		this.cache = new Keyv({
-			uri: typeof cacheAdapter === 'string' && cacheAdapter,
-			store: typeof cacheAdapter !== 'string' && cacheAdapter,
-			namespace: 'cacheable-request'
-		});
+		if (cacheAdapter instanceof Keyv) {
+			this.cache = cacheAdapter;
+		} else {
+			this.cache = new Keyv({
+				uri: typeof cacheAdapter === 'string' && cacheAdapter,
+				store: typeof cacheAdapter !== 'string' && cacheAdapter,
+				namespace: 'cacheable-request'
+			});
+		}
 
 		return this.createCacheableRequest(request);
 	}


### PR DESCRIPTION
This feature allows external libraries that wraps `cacheable-request` to have control on the `keyv` cache instance while still defaulting to current behavior.

ref: https://github.com/sindresorhus/got/issues/1523