### PR TITLE
test(100%): add case to reach coverage

### DIFF
--- a/test/cache.js
+++ b/test/cache.js
@@ -8,6 +8,7 @@ import delay from 'delay';
 import sqlite3 from 'sqlite3';
 import pify from 'pify';
 import CacheableRequest from 'this';
+import Keyv from 'keyv';
 
 let s;
 
@@ -539,6 +540,16 @@ test('Undefined callback parameter inside cache logic is handled', async t => {
 	cacheableRequest(s.url + endpoint);
 	await delay(500);
 	t.pass();
+});
+
+test('Custom Keyv instance adapters used', async t => {
+	const cache = new Keyv();
+	const endpoint = '/cache';
+	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequestHelper = promisify(cacheableRequest);
+	const response = await cacheableRequestHelper(s.url + endpoint);
+	const cached = await cache.get(`GET:${s.url + endpoint}`);
+	t.is(response.body, cached.body.toString());
 });
 
 test('Keyv cache adapters load via connection uri', async t => {

--- a/test/cacheable-request-class.js
+++ b/test/cacheable-request-class.js
@@ -1,5 +1,6 @@
 import { request } from 'http';
 import test from 'ava';
+import Keyv from 'keyv';
 import CacheableRequest from 'this';
 
 test('CacheableRequest is a function', t => {
@@ -16,4 +17,8 @@ test('CacheableRequest throws TypeError if request fn isn\'t passed in', t => {
 		new CacheableRequest(); // eslint-disable-line no-new
 	}, TypeError);
 	t.is(error.message, 'Parameter `request` must be a function');
+});
+
+test('CacheableRequest accepts Keyv instance', t => {
+	t.notThrows(() => new CacheableRequest(request, new Keyv()));
 });


### PR DESCRIPTION
As mentioned in [#101](https://github.com/jaredwray/cacheable-request/pull/101) I've added a couple of test cases.

About documentation I seen that Luke already documented years ago the possibility of passing an [instance of keyv](https://github.com/jaredwray/cacheable-request#storageadapter), maybe the feature was there in the past but got removed