### PR TITLE
updating docs and prepare when publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,28 @@
 ## Breaking Changes with v10.0.0
 This release contains breaking changes. This is the new way to use this package.
 
+### Usage Before v10
+```js
+import http from 'http';
+import CacheableRequest from 'cacheable-request';
+
+// Then instead of
+const req = http.request('http://example.com', cb);
+req.end();
+
+// You can do
+const cacheableRequest = new CacheableRequest(http.request);
+const cacheReq = cacheableRequest('http://example.com', cb);
+cacheReq.on('request', req => req.end());
+// Future requests to 'example.com' will be returned from cache if still valid
+
+// You pass in any other http.request API compatible method to be wrapped with cache support:
+const cacheableRequest = new CacheableRequest(https.request);
+const cacheableRequest = new CacheableRequest(electron.net);
+```
+
+### Usage After v10
+
 ```js
 import CacheableRequest from 'cacheable-request';
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 `cacheable-request` has recently been upgraded with needed security fixes. Please upgrade to the latest version. We upgrade dependent modules on a monthly basis with a minor version release. 
 
-## Note: we will only support v8.x.x until end of year (2022) with any security fixes.
+## Note :warning: we will only support v8.x.x until end of year (2022) with any security fixes.
 
 | Version | Supported          |
 | ------- | ------------------ |

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	},
 	"scripts": {
 		"test": "xo && NODE_OPTIONS=--experimental-vm-modules jest --coverage ",
+		"prepare": "npm run build",
 		"build": "tsc --project tsconfig.build.json",
 		"clean": "rm -rf node_modules && rm -rf ./coverage && rm -rf ./package-lock.json && rm -rf ./test/testdb.sqlite && rm -rf ./dist"
 	},


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable-request/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Some small changes to help things out:
- Updated Readme with before v10 and now on the breaking change
- Made the package.json do a `prepare` to compile typescript code in the `dist` folder before publishing
- Updated the security notes to be clear we will no longer support v8 after 2022
