### PR TITLE
Moved @types/http-cache-semantics to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"compliant"
 	],
 	"dependencies": {
+		"@types/http-cache-semantics": "^4.0.1",
 		"get-stream": "^6.0.1",
 		"http-cache-semantics": "^4.1.0",
 		"keyv": "^4.5.0",
@@ -45,7 +46,6 @@
 		"@types/create-test-server": "^3.0.1",
 		"@types/delay": "^3.1.0",
 		"@types/get-stream": "^3.0.2",
-		"@types/http-cache-semantics": "^4.0.1",
 		"@types/jest": "^29.0.3",
 		"@types/node": "^18.7.18",
 		"@types/responselike": "^1.0.0",


### PR DESCRIPTION
Fixes #194

It looks like it's not a dev-only dependency as it prevents pendants from using this project, so I think that the move is justified.

Tested using npm link, it works and solves my problem.

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable-request/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix