### PR TITLE
Move @types/http-cache-semantics from dev to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
 		"7234",
 		"compliant"
 	],
+	"dependenciesComments": {
+		"@types/http-cache-semantics": "It needs to be in the dependencies list and not devDependencies because otherwise projects that use this one will be getting `Could not find a declaration file for module 'http-cache-semantics'` error when running `tsc`, see https://github.com/jaredwray/cacheable-request/issues/194 for details"
+	},
 	"dependencies": {
+		"@types/http-cache-semantics": "^4.0.1",
 		"get-stream": "^6.0.1",
 		"http-cache-semantics": "^4.1.0",
 		"keyv": "^4.5.2",
@@ -42,7 +46,6 @@
 	},
 	"devDependencies": {
 		"@keyv/sqlite": "^3.6.4",
-		"@types/http-cache-semantics": "^4.0.1",
 		"@types/delay": "^3.1.0",
 		"@types/get-stream": "^3.0.2",
 		"@types/jest": "^29.2.4",

--- a/test/dependencies.test.ts
+++ b/test/dependencies.test.ts
@@ -1,0 +1,13 @@
+import {readFileSync} from 'node:fs';
+
+test('@types/http-cache-semantics is a regular (not dev) dependency', () => {
+	// Required to avoid `Could not find a declaration file for module 'http-cache-semantics'` error from `tsc` when using this package in other projects
+
+	// Arrange
+	const packageJsonContents = JSON.parse(
+		readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+	);
+
+	// Assert
+	expect(packageJsonContents).toHaveProperty('dependencies.@types/http-cache-semantics');
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable-request/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Moves `@types/http-cache-semantics` from dev-deps to deps, and adds a test to prevent regressions.

Fixes https://github.com/jaredwray/cacheable-request/issues/218