### PR TITLE
reverting back to previous get-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cacheable-request",
-	"version": "10.2.11",
+	"version": "10.2.12",
 	"description": "Wrap native HTTP requests with RFC compliant cache support",
 	"license": "MIT",
 	"repository": "jaredwray/cacheable-request",
@@ -37,7 +37,7 @@
 	},
 	"dependencies": {
 		"@types/http-cache-semantics": "^4.0.1",
-		"get-stream": "^7.0.0",
+		"get-stream": "^6.0.1",
 		"http-cache-semantics": "^4.1.1",
 		"keyv": "^4.5.2",
 		"mimic-response": "^4.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import crypto from 'node:crypto';
 import stream, {PassThrough as PassThroughStream} from 'node:stream';
 import {IncomingMessage} from 'node:http';
 import normalizeUrl from 'normalize-url';
-import {getStreamAsBuffer} from 'get-stream';
+import getStream from 'get-stream';
 import CachePolicy from 'http-cache-semantics';
 import Response from 'responselike';
 import Keyv from 'keyv';
@@ -127,7 +127,7 @@ class CacheableRequest {
 					clonedResponse = cloneResponse(response);
 					(async () => {
 						try {
-							const bodyPromise = getStreamAsBuffer(response);
+							const bodyPromise = getStream.buffer(response);
 							await Promise.race([
 								requestErrorPromise,
 								new Promise(resolve => response.once('end', resolve)), // eslint-disable-line no-promise-executor-return


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable-request/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is being done due to the issues with get-stream 7 needing compatibility with Nodejs 16
